### PR TITLE
refactor: update permissions in release workflow and improve comments…

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,6 @@
 name: Pull Request Tests
 
 on:
-  push:
-    branches: [dev]
   pull_request:
     branches: [dev, main]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/scripts/create-release.sh
+++ b/.github/workflows/scripts/create-release.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -e
 
-# 設定
+# Configuration
 REPO_NAME="redmine-markdown-editor-crx"
 DATE=$(date +'%Y.%m.%d')
 
 echo "=== Creating release for $REPO_NAME ==="
 echo "Date: $DATE"
 
-# GitHub APIを使用して同日のリリース数を取得
+# Use GitHub API to get the number of releases for today
 echo "Checking existing releases for today..."
 RELEASES_TODAY=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  "https://api.github.com/repos/$GITHUB_REPOSITORY/releases" | \
-  jq -r --arg date "$DATE" '[.[] | select(.tag_name | contains($date)) | .tag_name] | length')
+    "https://api.github.com/repos/$GITHUB_REPOSITORY/releases" |
+    jq -r --arg date "$DATE" '[.[] | select(.tag_name | contains($date)) | .tag_name] | length')
 
-# 同日のリリース番号（0から始まる）
+# Release number for the same day (starting from 0)
 RELEASE_NUMBER=$RELEASES_TODAY
 VERSION="${DATE}.${RELEASE_NUMBER}"
 FILENAME="${REPO_NAME}-v${VERSION}"
@@ -23,26 +23,26 @@ echo "Release number for today: $RELEASE_NUMBER"
 echo "Generated version: $VERSION"
 echo "Generated filename: $FILENAME"
 
-# 出力をGitHub Actionsに渡す
+# Pass output to GitHub Actions
 if [ -n "$GITHUB_OUTPUT" ]; then
-    echo "version=$VERSION" >> $GITHUB_OUTPUT
-    echo "filename=$FILENAME" >> $GITHUB_OUTPUT
+    echo "version=$VERSION" >>$GITHUB_OUTPUT
+    echo "filename=$FILENAME" >>$GITHUB_OUTPUT
 fi
 
-# manifest.jsonのバージョンを更新
+# Update manifest.json version
 echo "Updating manifest.json version..."
 if [ -f "dist/manifest.json" ]; then
     npx dot-json@1 dist/manifest.json version "$VERSION"
     echo "Updated manifest.json version to: $VERSION"
-    
-    # 更新されたバージョンを確認
+
+    # Verify the updated version
     UPDATED_VERSION=$(npx dot-json@1 dist/manifest.json version)
     echo "Verified manifest.json version: $UPDATED_VERSION"
 else
     echo "Warning: dist/manifest.json not found"
 fi
 
-# distフォルダをリネームしてZIPを作成
+# Rename dist folder and create ZIP archive
 echo "Creating ZIP archive..."
 if [ -d "dist" ]; then
     mv dist "$FILENAME"


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and the release script to improve automation and clarity. The changes focus on permissions configuration, script comments, and handling versioning for releases.

### GitHub Actions Workflow Updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R13-R15): Added `permissions` configuration to allow writing to `contents` and `packages`, ensuring proper permissions for release-related tasks.

### Release Script Improvements:
* [`.github/workflows/scripts/create-release.sh`](diffhunk://#diff-3b1b045967bc53b41fd90533a175ec25a196534d8e8cf742d71ac9f0c56f1c49L4-R17): Updated comments throughout the script to replace Japanese text with English, improving readability and accessibility for a broader audience. [[1]](diffhunk://#diff-3b1b045967bc53b41fd90533a175ec25a196534d8e8cf742d71ac9f0c56f1c49L4-R17) [[2]](diffhunk://#diff-3b1b045967bc53b41fd90533a175ec25a196534d8e8cf742d71ac9f0c56f1c49L26-R45)… in create-release script