### PR TITLE
refactor: update release workflow and scripts for clarity and consist…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
 
-      - name: Create Release
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: "v${{ steps.package.outputs.version }}"

--- a/.github/workflows/scripts/create-release.sh
+++ b/.github/workflows/scripts/create-release.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 REPO_NAME="redmine-markdown-editor-crx"
-DATE=$(date +'%Y.%m.%d')
+DATE=$(date +'%y.%m.%d')
 
 echo "=== Creating release for $REPO_NAME ==="
 echo "Date: $DATE"

--- a/.github/workflows/templates/release-body.md
+++ b/.github/workflows/templates/release-body.md
@@ -3,9 +3,7 @@
 2. Open Chrome Extensions page (`chrome://extensions/`) and enable Developer mode
 3. Click "Load unpacked" and select the extracted folder
 
-[Chrome Extension Privacy Policy](https://mimimiku778.github.io/privacy/en.html)
-This extension is provided "as is" without warranty of any kind.  
-The author is not responsible for any damages or losses caused by the use of this extension.
+[Chrome Extension Privacy Policy](https://mimimiku778.github.io/privacy/en.html) | [MIT License](https://github.com/mimimiku778/redmine-markdown-editor-crx/blob/main/LICENSE)
 
 ---
 ### インストール方法
@@ -13,6 +11,4 @@ The author is not responsible for any damages or losses caused by the use of thi
 2. Chromeの拡張機能ページ（chrome://extensions/）で「デベロッパーモード」をON
 3. 「パッケージ化されていない拡張機能を読み込む」から解凍フォルダを選択
 
-[Chrome 拡張のプライバシーポリシー](https://mimimiku778.github.io/privacy/ja.html)
-本拡張機能は現状のまま提供されており、いかなる種類の保証も行いません。  
-本拡張機能の利用によって生じたいかなる損害や損失についても、作者は一切の責任を負いません。
+[Chrome 拡張のプライバシーポリシー](https://mimimiku778.github.io/privacy/ja.html) | [MIT License](https://github.com/mimimiku778/redmine-markdown-editor-crx/blob/main/LICENSE)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 mimimiku778
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "version": "1.0.0",
     "type": "module",
     "description": "Chrome extension that adds a CodeMirror-based Markdown editor to Redmine textareas",
+    "license": "MIT",
     "scripts": {
         "dev": "vite",
         "build": "tsc -b && vite build",


### PR DESCRIPTION
…ency
This pull request introduces several updates to the repository, including workflow improvements, licensing changes, and adjustments to release scripts and templates. The most notable changes involve the addition of an MIT license, updates to the release process, and modifications to the privacy policy and release documentation.

### Workflow and release process improvements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L34-R34): Renamed the step from "Create Release" to "Create GitHub Release" for clarity.
* [`.github/workflows/scripts/create-release.sh`](diffhunk://#diff-3b1b045967bc53b41fd90533a175ec25a196534d8e8cf742d71ac9f0c56f1c49L6-R6): Changed the date format in the release script from `%Y.%m.%d` to `%y.%m.%d` for a shorter representation.

### Licensing updates:
* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7R1-R21): Added an MIT License file to the repository, granting permission for free use, modification, and distribution under specified conditions.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R7): Declared the license as "MIT" in the package metadata.

### Documentation updates:
* [`.github/workflows/templates/release-body.md`](diffhunk://#diff-74a159fa9f7c07258fddd532578ef5f425eece20dbd9c152cf930c4f4672c059L6-R14): Updated the privacy policy section to include a reference to the MIT License.