### PR TITLE
refactor: update date format in create-release script for consistency

### DIFF
--- a/.github/workflows/scripts/create-release.sh
+++ b/.github/workflows/scripts/create-release.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 REPO_NAME="redmine-markdown-editor-crx"
-DATE=$(date +'%y.%m.%d')
+DATE=$(date +'%y.%-m.%-d')
 
 echo "=== Creating release for $REPO_NAME ==="
 echo "Date: $DATE"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/scripts/create-release.sh` file. The change modifies the date format in the `DATE` variable to ensure single-digit months and days are not padded with a leading zero.