### PR TITLE
fix: add background color for selection match in code editor

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,6 +3,6 @@
     "message": "Redmine Markdown Editor Plus"
   },
   "ext_desc": {
-    "message": "Adds a CodeMirror-based Markdown editor to Redmine textareas with syntax highlighting, live preview, and enhanced editing capabilities."
+    "message": "Adds a CodeMirror-based Markdown editor to Redmine with syntax highlighting, live preview, and enhanced editing capabilities."
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -38,3 +38,7 @@
 .cm-theme.md-editor-inner {
   cursor: text;
 }
+
+.cm-selectionMatch {
+  background-color: #99ff7780 !important;
+}


### PR DESCRIPTION
This pull request introduces a small visual enhancement to the markdown editor's theme. A new CSS rule highlights matching selections with a translucent green background color.

* [`src/index.css`](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR41-R44): Added the `.cm-selectionMatch` class to apply a translucent green background (`#99ff7780`) to matching selections in the markdown editor.