### PR TITLE
fix: restore Chrome Web Store upload step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      #- name: Upload to Chrome Web Store
-      #  if: steps.package.outputs.skip_release != 'true'
-      #  uses: mobilefirstllc/cws-publish@v1
-      #  with:
-      #    refresh_token: ${{ secrets.CHROME_REFRESH_TOKEN }}
-      #    client_id: ${{ secrets.CHROME_CLIENT_ID }}
-      #    client_secret: ${{ secrets.CHROME_CLIENT_SECRET }}
-      #    extension_id: ${{ secrets.CHROME_EXTENSION_ID }}
-      #    zip_file: ./${{ steps.package.outputs.filename }}.zip
+      - name: Upload to Chrome Web Store
+        if: steps.package.outputs.skip_release != 'true'
+        uses: mobilefirstllc/cws-publish@v1
+        with:
+          refresh_token: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          client_id: ${{ secrets.CHROME_CLIENT_ID }}
+          client_secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+          extension_id: ${{ secrets.CHROME_EXTENSION_ID }}
+          zip_file: ./${{ steps.package.outputs.filename }}.zip


### PR DESCRIPTION
This pull request re-enables the "Upload to Chrome Web Store" step in the GitHub Actions workflow for releases by uncommenting the relevant configuration in `.github/workflows/release.yml`.

* Workflow updates:
  * Re-enabled the "Upload to Chrome Web Store" step in the `release.yml` workflow by uncommenting the configuration. This step uses the `mobilefirstllc/cws-publish@v1` action to upload the packaged extension to the Chrome Web Store if the `skip_release` output is not `true`.