### PR TITLE
fix: update Chrome Web Store upload step to use CLI for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,12 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload to Chrome Web Store
         if: steps.package.outputs.skip_release != 'true'
-        uses: mobilefirstllc/cws-publish@v1
-        with:
-          refresh_token: ${{ secrets.CHROME_REFRESH_TOKEN }}
-          client_id: ${{ secrets.CHROME_CLIENT_ID }}
-          client_secret: ${{ secrets.CHROME_CLIENT_SECRET }}
-          extension_id: ${{ secrets.CHROME_EXTENSION_ID }}
-          zip_file: ./${{ steps.package.outputs.filename }}.zip
+        run: |
+          npx chrome-webstore-upload-cli@2 upload --source ${{ steps.package.outputs.filename }}.zip --auto-publish
+        env:
+          EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}


### PR DESCRIPTION
This pull request updates the release workflow for publishing to the Chrome Web Store by replacing the `mobilefirstllc/cws-publish` GitHub Action with the `chrome-webstore-upload-cli` package. This change simplifies the process by using a direct CLI command.

### Workflow update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L46-R54): Replaced the `mobilefirstllc/cws-publish` GitHub Action with an `npx` command to use `chrome-webstore-upload-cli@2` for uploading and auto-publishing Chrome extensions. Updated the environment variables to match the CLI tool's requirements.